### PR TITLE
Html leaf node

### DIFF
--- a/src/htmlnode.py
+++ b/src/htmlnode.py
@@ -2,7 +2,8 @@ class HTMLNode:
     """
     class to represent HTML tags
     """
-    def __init__(self, tag = None, value = None, children = None, props = None):
+
+    def __init__(self, tag=None, value=None, children=None, props=None):
         self.tag = tag
         self.value = value
         self.children = children
@@ -23,7 +24,7 @@ class HTMLNode:
         return props_html
 
     def __repr__(self):
-        return f'''{self.__class__.__name__}({self.tag}, {self.value}, {self.children}, {self.props})'''
+        return f"""{self.__class__.__name__}({self.tag}, {self.value}, {self.children}, {self.props})"""
 
 
 class LeafNode(HTMLNode):
@@ -31,14 +32,16 @@ class LeafNode(HTMLNode):
     class to represent HTML tags that do not have children
     For e.g. a simple <p> tag with simple text, has no nested children
     """
-    def __init__(self, tag, value, props = None):
+
+    def __init__(self, tag, value, props=None):
         super().__init__(tag=tag, value=value, children=None, props=props)
 
     def to_html(self) -> str:
         """
         Method to render the leaf node as HTML string
         """
-        if self.value is None: raise ValueError("Invalid HTML: no value")
+        if self.value is None:
+            raise ValueError("Invalid HTML: no value")
         if self.tag is None:
             return self.value
 
@@ -46,4 +49,3 @@ class LeafNode(HTMLNode):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.tag}, {self.value}, {self.props})"
-

--- a/src/test_htmlnode.py
+++ b/src/test_htmlnode.py
@@ -1,5 +1,5 @@
 import unittest
-from htmlnode import HTMLNode
+from htmlnode import HTMLNode, LeafNode
 
 
 class TestHTMLNode(unittest.TestCase):
@@ -14,6 +14,18 @@ class TestHTMLNode(unittest.TestCase):
         self.assertEqual(
             node.props_to_html(), ' class="greeting" href="https://boot.dev"'
         )
+
+    def test_to_html_leafnode(self):
+        tag = "p"
+        text = "Hello World!"
+        node = LeafNode(tag, text)
+        self.assertEqual(node.to_html(), f"<{tag}>{text}</{tag}>")
+
+    def test_to_html_leafnode_no_tag(self):
+        tag = None
+        text = "Hello, World!"
+        node = LeafNode(tag=tag, value=text)
+        self.assertEqual(node.to_html(), text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Leaf Node implementation (extending a HTML node).

Leaf Node is used to represent HTML nodes that have no children.