### PR TITLE
Helper: Text to textnodes

### DIFF
--- a/src/inline_markdown.py
+++ b/src/inline_markdown.py
@@ -2,12 +2,24 @@ import re
 from textnode import (
     TextNode,
     text_type_text,
-    # text_type_bold,
-    # text_type_italic,
-    # text_type_code,
+    text_type_bold,
+    text_type_italic,
+    text_type_code,
     text_type_image,
     text_type_link,
 )
+
+delimiter_map = {"**": text_type_bold, "*": text_type_italic, "`": text_type_code}
+
+
+def text_to_textnodes(text: str) -> list["TextNode"]:
+    nodes = [TextNode(text, text_type_text)]
+    for delimiter, text_type in delimiter_map.items():
+        nodes = split_nodes_delimiter(nodes, delimiter, text_type)
+    nodes = split_nodes_image(nodes)
+    nodes = split_nodes_link(nodes)
+
+    return nodes
 
 
 def split_nodes_delimiter(old_nodes, delimiter, text_type):

--- a/src/test_inlinemarkdown.py
+++ b/src/test_inlinemarkdown.py
@@ -5,6 +5,7 @@ from inline_markdown import (
     extract_markdown_images,
     split_nodes_image,
     split_nodes_link,
+    text_to_textnodes,
 )
 from textnode import (
     TextNode,
@@ -235,6 +236,31 @@ class TestInlineMarkdown(unittest.TestCase):
                 TextNode("But wait, there's more - ", text_type_text),
                 TextNode(alt_texts[2], text_type_link, urls[2]),
             ],
+        )
+
+    def test_text_to_textnodes(self):
+        """
+        Test case to check text_to_textnodes helper
+        """
+        input_text = "This is **text** with an *italic* word and a `code block` and an ![image](https://storage.googleapis.com/qvault-webapp-dynamic-assets/course_assets/zjjcJKZ.png) and a [link](https://boot.dev)"
+        self.assertEqual(
+            [
+                TextNode("This is ", text_type_text),
+                TextNode("text", text_type_bold),
+                TextNode(" with an ", text_type_text),
+                TextNode("italic", text_type_italic),
+                TextNode(" word and a ", text_type_text),
+                TextNode("code block", text_type_code),
+                TextNode(" and an ", text_type_text),
+                TextNode(
+                    "image",
+                    text_type_image,
+                    "https://storage.googleapis.com/qvault-webapp-dynamic-assets/course_assets/zjjcJKZ.png",
+                ),
+                TextNode(" and a ", text_type_text),
+                TextNode("link", text_type_link, "https://boot.dev"),
+            ],
+            text_to_textnodes(input_text),
         )
 
 


### PR DESCRIPTION
Helper function to break a markdown text into a list of textnodes (bold/italic/code/image/link).